### PR TITLE
create DM delay code and tests

### DIFF
--- a/arts/observation.py
+++ b/arts/observation.py
@@ -61,7 +61,7 @@ class Observation(Telescope):
             t_delay = (
                 4148808 * dm * ((lf ** (-2)) - (hf ** (-2)))
             )  # delay across BW in ms
-        elif t_out == "lowchan":
+        elif t_out == "lochan":
             t_delay = (
                 4148808 * dm * ((lf ** (-2)) - (lowchan_end ** (-2)))
             )  # delay across lowest channel in ms

--- a/arts/observation.py
+++ b/arts/observation.py
@@ -34,12 +34,26 @@ class Observation(Telescope):
         """
 
         Args:
-            dm:
+            dm (float): dispersion measure (pc/cm^3)
 
-        Returns:
+        Returns: 
+            t_delay_bw (float): dispersion delay across bandwidth in ms
+            t_delay_lowchan (float): dispersion delay across lowest frequency channel in ms
+            t_delay_hichan (float): dispersion delay across highest frequency channel in ms
 
         """
-        return 0
+        hf = self.center_freq + (self.bandwidth/2.)
+        lf = self.center_freq - (self.bandwidth/2.)
+        #Make sure frequencies are in MHz otherwise this is wrong
+
+        chan_width = self.bandwidth/self.nchans
+        lowchan_end = lf + chan_width #upper frequency of lowest-frequency channel
+        hichan_start = hf - chan_width #lower frequency of highest-frequency channel
+
+        t_delay_bw = 4148808 * dm * ( (lf**(-2)) - (hf**(-2)) ) #delay across BW in ms
+        t_delay_lowchan = 4148808 * dm * ( (lf**(-2)) - (lowchan_end**(-2)) ) #delay across lowest channel in ms
+        t_delay_hichan = 4148808 * dm * ( (hichan_start**(-2)) - (hf**(-2)) ) #delay across highest channel in ms
+        return t_delay_bw, t_delay_lowchan, t_delay_hichan
 
     def dm_smear_intrachan(self):
         """

--- a/arts/observation.py
+++ b/arts/observation.py
@@ -70,6 +70,8 @@ class Observation(Telescope):
                 4148808 * dm * ((hichan_start ** (-2)) - (hf ** (-2)))
             )  # delay across highest channel in ms
 
+        return t_delay
+
     def dm_smear_intrachan(self):
         """
 

--- a/arts/observation.py
+++ b/arts/observation.py
@@ -30,30 +30,45 @@ class Observation(Telescope):
         """
         return 0
 
-    def dm_delay(self, dm):
+    def dm_delay(self, dm, t_out="bw"):
         """
-
         Args:
             dm (float): dispersion measure (pc/cm^3)
+            t_out (str): which dispersion delay the function returns.
+              Default: "bw" = delay across entire bandwidth
+              "hichan" = delay across highest frequency channel
+              "lochan" = delay across lowest frequency channel
 
-        Returns: 
-            t_delay_bw (float): dispersion delay across bandwidth in ms
-            t_delay_lowchan (float): dispersion delay across lowest frequency channel in ms
-            t_delay_hichan (float): dispersion delay across highest frequency channel in ms
+        Returns:
+            t_delay (float): dispersion delay across desired frequency range, in ms
 
         """
-        hf = self.center_freq + (self.bandwidth/2.)
-        lf = self.center_freq - (self.bandwidth/2.)
-        #Make sure frequencies are in MHz otherwise this is wrong
 
-        chan_width = self.bandwidth/self.nchans
-        lowchan_end = lf + chan_width #upper frequency of lowest-frequency channel
-        hichan_start = hf - chan_width #lower frequency of highest-frequency channel
+        hf = self.center_freq + (self.bandwidth / 2.0)
+        lf = self.center_freq - (self.bandwidth / 2.0)
+        # Make sure frequencies are in MHz otherwise this is wrong
 
-        t_delay_bw = 4148808 * dm * ( (lf**(-2)) - (hf**(-2)) ) #delay across BW in ms
-        t_delay_lowchan = 4148808 * dm * ( (lf**(-2)) - (lowchan_end**(-2)) ) #delay across lowest channel in ms
-        t_delay_hichan = 4148808 * dm * ( (hichan_start**(-2)) - (hf**(-2)) ) #delay across highest channel in ms
-        return t_delay_bw, t_delay_lowchan, t_delay_hichan
+        chan_width = self.bandwidth / self.nchans
+        lowchan_end = lf + chan_width  # upper frequency of lowest-frequency channel
+        hichan_start = hf - chan_width  # lower frequency of highest-frequency channel
+
+        if t_out not in ["bw", "hichan", "lochan"]:
+            raise ValueError(
+                "Output string should be one of the preset values: 'bw', 'hichan', or 'lochan'"
+            )
+
+        if t_out == "bw":
+            t_delay = (
+                4148808 * dm * ((lf ** (-2)) - (hf ** (-2)))
+            )  # delay across BW in ms
+        elif t_out == "lowchan":
+            t_delay = (
+                4148808 * dm * ((lf ** (-2)) - (lowchan_end ** (-2)))
+            )  # delay across lowest channel in ms
+        elif t_out == "hichan":
+            t_delay = (
+                4148808 * dm * ((hichan_start ** (-2)) - (hf ** (-2)))
+            )  # delay across highest channel in ms
 
     def dm_smear_intrachan(self):
         """

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -25,12 +25,12 @@ def test_dm_delay():
     in_strs = ["bw", "lochan", "hichan"]
     # Check that delay = 0 when DM = 0
     for instr in in_strs:
-        assert pytest.approx(obs.dm_delay(0, instr), rel=1e-6) == 0.0
+        assert pytest.approx(myobs.dm_delay(0, instr), rel=1e-6) == 0.0
 
     # Check math for known calculation
-    assert pytest.approx(obs.dm_delay(20), rel=1e-3) == 403.356333333334
-    assert pytest.approx(obs.dm_delay(20, "lochan"), rel=1e-3) == 1.19929396522448
-    assert pytest.approx(obs.dm_delay(20, "hichan"), rel=1e-3) == 0.50681746304299
+    assert pytest.approx(myobs.dm_delay(20), rel=1e-3) == 403.356333333334
+    assert pytest.approx(myobs.dm_delay(20, "lochan"), rel=1e-3) == 1.19929396522448
+    assert pytest.approx(myobs.dm_delay(20, "hichan"), rel=1e-3) == 0.50681746304299
 
     # Check that delay = 0 when bandwidth = 0
     setattr(myobs, "bandwidth", 0)

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -18,20 +18,25 @@ def test_min_flux():
 
 def test_dm_delay():
     myobs = Observation()
-    setattr(myobs,'bandwidth',100)
-    setattr(myobs,'center_freq',350)
-    setattr(myobs,'nchans',512)
+    setattr(myobs, "bandwidth", 100)
+    setattr(myobs, "center_freq", 350)
+    setattr(myobs, "nchans", 512)
 
-    #Check that delay = 0 when DM = 0
-    for i in range(3):
-        assert pytest.approx(obs.dm_delay(dm=0)[i], rel=1e-6) == 0.
+    in_strs = ["bw", "lochan", "hichan"]
+    # Check that delay = 0 when DM = 0
+    for instr in in_strs:
+        assert pytest.approx(obs.dm_delay(0, instr), rel=1e-6) == 0.0
 
-    #Check math for known calculation
-    assert pytest.approx(obs.dm_delay(dm=20)[0], rel=1e-3) == 403.356333333334
-    assert pytest.approx(obs.dm_delay(dm=20)[1], rel=1e-3) == 1.19929396522448
-    assert pytest.approx(obs.dm_delay(dm=20)[2], rel=1e-3) == 0.50681746304299
+    # Check math for known calculation
+    assert pytest.approx(obs.dm_delay(20), rel=1e-3) == 403.356333333334
+    assert pytest.approx(obs.dm_delay(20, "lochan"), rel=1e-3) == 1.19929396522448
+    assert pytest.approx(obs.dm_delay(20, "hichan"), rel=1e-3) == 0.50681746304299
 
-    #Check that delay = 0 when bandwidth = 0
-    setattr(myobs,'bandwidth',0)
-    for i in range(3):
-       assert pytest.approx(myobs.dm_delay(50)[i],rel=1e-6) == 0.
+    # Check that delay = 0 when bandwidth = 0
+    setattr(myobs, "bandwidth", 0)
+    for instr in in_strs:
+        assert pytest.approx(myobs.dm_delay(50, instr), rel=1e-6) == 0.0
+
+    # Check that error is raised when invalid string is passed
+    with pytest.raises(ValueError):
+        obs.dm_delay(20, "abcdef")

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -39,4 +39,4 @@ def test_dm_delay():
 
     # Check that error is raised when invalid string is passed
     with pytest.raises(ValueError):
-        obs.dm_delay(20, "abcdef")
+        myobs.dm_delay(20, "abcdef")

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import pytest
 from arts.observation import Observation
 from arts.telescope import Telescope
 
@@ -17,4 +17,21 @@ def test_min_flux():
 
 
 def test_dm_delay():
-    assert 1 == 1
+    myobs = Observation()
+    setattr(myobs,'bandwidth',100)
+    setattr(myobs,'center_freq',350)
+    setattr(myobs,'nchans',512)
+
+    #Check that delay = 0 when DM = 0
+    for i in range(3):
+        assert pytest.approx(obs.dm_delay(dm=0)[i], rel=1e-6) == 0.
+
+    #Check math for known calculation
+    assert pytest.approx(obs.dm_delay(dm=20)[0], rel=1e-3) == 403.356333333334
+    assert pytest.approx(obs.dm_delay(dm=20)[1], rel=1e-3) == 1.19929396522448
+    assert pytest.approx(obs.dm_delay(dm=20)[2], rel=1e-3) == 0.50681746304299
+
+    #Check that delay = 0 when bandwidth = 0
+    setattr(myobs,'bandwidth',0)
+    for i in range(3):
+       assert pytest.approx(myobs.dm_delay(50)[i],rel=1e-6) == 0.


### PR DESCRIPTION
Added DM delay calculation as a function in arts/observation.py. Center frequencies/bandwidths need to be in MHz for this to work properly; not sure if there's a good way to make sure this is always the case.

Added test cases to tests/test_observation.py. Using pytest.approx to make sure DM delay is 0 when bandwidth/DM are 0, and checks math against one test case.